### PR TITLE
Support for OKE images & aarch64, added v1.24.1 and node_eviction_node_pool_settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ cluster_options_add_ons_is_kubernetes_dashboard_enabled | If you want to set clu
 cluster_options_add_ons_is_tiller_enabled | If you want to use Tiller then you need to set the value to TRUE.
 node_pool_initial_node_labels_key | You can pass here node_pool_initial_node_labels_key.
 node_pool_initial_node_labels_value | You can pass here node_pool_initial_node_labels_value.
+node_eviction_node_pool_settings | If you want to setup Node Eviction Details configuration then set the value to TRUE (by default the value is equal to FALSE).
+eviction_grace_duration | If node_eviction_node_pool_settings is set to TRUE then you can setup duration after which OKE will give up eviction of the pods on the node. PT0M will indicate you want to delete the node without cordon and drain. Default PT60M, Min PT0M, Max: PT60M. Format ISO 8601 e.g PT30M
+is_force_delete_after_grace_duration | If node_eviction_node_pool_settings is set to TRUE then you can setup underlying compute instance to be deleted event if you cannot evict all the pods in grace period.
 ssh_public_key | If you want to use your own SSH public key instead of generated onne by the module.
 
 ## Contributing

--- a/examples/oke-native-pod-ips/oke.tf
+++ b/examples/oke-native-pod-ips/oke.tf
@@ -2,26 +2,31 @@
 ## All rights reserved. The Universal Permissive License (UPL), Version 1.0 as shown at http://oss.oracle.com/licenses/upl
 
 module "oci-oke" {
-  source                        = "github.com/oracle-devrel/terraform-oci-arch-oke"
-  tenancy_ocid                  = var.tenancy_ocid
-  compartment_ocid              = var.compartment_ocid
-  oke_cluster_name              = var.oke_cluster_name
-  k8s_version                   = var.k8s_version
-  pool_name                     = var.pool_name
-  node_shape                    = var.node_shape
-  node_ocpus                    = var.node_ocpus
-  node_memory                   = var.node_memory
-  node_count                    = var.node_count
-  use_existing_vcn              = true
-  vcn_id                        = oci_core_vcn.my_vcn.id
-  is_api_endpoint_subnet_public = false
-  api_endpoint_subnet_id        = oci_core_subnet.my_api_endpoint_subnet.id
-  is_lb_subnet_public           = false
-  lb_subnet_id                  = oci_core_subnet.my_lb_subnet.id
-  is_nodepool_subnet_public     = false
-  nodepool_subnet_id            = oci_core_subnet.my_pods_nodepool_subnet.id
-  oci_vcn_ip_native             = true 
-  max_pods_per_node             = 10
-  pods_subnet_id                = oci_core_subnet.my_pods_nodepool_subnet.id
+  #source                              = "github.com/oracle-devrel/terraform-oci-arch-oke"
+  source                               = "../../"
+  tenancy_ocid                         = var.tenancy_ocid
+  compartment_ocid                     = var.compartment_ocid
+  oke_cluster_name                     = var.oke_cluster_name
+  k8s_version                          = var.k8s_version
+  pool_name                            = var.pool_name
+  node_shape                           = var.node_shape
+  node_ocpus                           = var.node_ocpus
+  node_memory                          = var.node_memory
+  node_count                           = var.node_count
+  node_linux_version                   = var.node_linux_version
+  use_existing_vcn                     = true
+  vcn_id                               = oci_core_vcn.my_vcn.id
+  is_api_endpoint_subnet_public        = false
+  api_endpoint_subnet_id               = oci_core_subnet.my_api_endpoint_subnet.id
+  is_lb_subnet_public                  = false
+  lb_subnet_id                         = oci_core_subnet.my_lb_subnet.id
+  is_nodepool_subnet_public            = false
+  nodepool_subnet_id                   = oci_core_subnet.my_pods_nodepool_subnet.id
+  oci_vcn_ip_native                    = true 
+  max_pods_per_node                    = 10
+  pods_subnet_id                       = oci_core_subnet.my_pods_nodepool_subnet.id
+  node_eviction_node_pool_settings     = true
+  eviction_grace_duration              = "PT0M"
+  is_force_delete_after_grace_duration = true
 }
 

--- a/examples/oke-native-pod-ips/variables.tf
+++ b/examples/oke-native-pod-ips/variables.tf
@@ -29,7 +29,7 @@ variable "oke_cluster_name" {
 }
 
 variable "k8s_version" {
-  default = "v1.23.4"
+  default = "v1.24.1"
 }
 
 variable "pool_name" {
@@ -37,7 +37,7 @@ variable "pool_name" {
 }
 
 variable "node_shape" {
-  default = "VM.Standard.E3.Flex"
+  default = "VM.Standard.A1.Flex"
 }
 
 variable "node_ocpus" {
@@ -52,3 +52,6 @@ variable "node_count" {
   default = 4
 }
 
+variable "node_linux_version" {
+  default = "8.6"
+}

--- a/locals.tf
+++ b/locals.tf
@@ -1,0 +1,7 @@
+locals {
+  availability_domains       = var.availability_domain == "" ? data.oci_identity_availability_domains.ADs.availability_domains : data.oci_identity_availability_domains.AD.availability_domains
+  is_arm_node_shape          = length(regexall("A1", var.node_shape)) > 0 ? true : false
+  arm_node_shape             = local.is_arm_node_shape ? "aarch64-" : ""
+  k8s_version_without_v_char = substr(var.k8s_version,1,6)
+  node_image_regex           = "Oracle-Linux-${var.node_linux_version}-${local.arm_node_shape}.+-OKE-${local.k8s_version_without_v_char}-[0-9]+"
+}

--- a/oke.tf
+++ b/oke.tf
@@ -57,13 +57,15 @@ resource "oci_containerengine_node_pool" "oci_oke_node_pool" {
   name               = var.pool_name
   node_shape         = var.node_shape
 
+
   initial_node_labels {
     key   = var.node_pool_initial_node_labels_key
     value = var.node_pool_initial_node_labels_value
   }
 
   node_source_details {
-    image_id                = var.node_image_id == "" ? element([for source in data.oci_containerengine_node_pool_option.oci_oke_node_pool_option.sources : source.image_id if length(regexall("Oracle-Linux-${var.node_linux_version}-20[0-9]*.*", source.source_name)) > 0], 0) : var.node_image_id
+    #image_id                = var.node_image_id == "" ? element([for source in data.oci_containerengine_node_pool_option.oci_oke_node_pool_option.sources : source.image_id if length(regexall("Oracle-Linux-${var.node_linux_version}-20[0-9]*.*", source.source_name)) > 0], 0) : var.node_image_id
+    image_id                = var.node_image_id == "" ? element([for source in data.oci_containerengine_node_pool_option.oci_oke_node_pool_option.sources : source.image_id if length(regexall(local.node_image_regex, source.source_name)) > 0], 0) : var.node_image_id
     source_type             = "IMAGE"
     boot_volume_size_in_gbs = var.node_pool_boot_volume_size_in_gbs
   }
@@ -100,6 +102,16 @@ resource "oci_containerengine_node_pool" "oci_oke_node_pool" {
       memory_in_gbs = var.node_memory
     }
   }
+
+  dynamic "node_eviction_node_pool_settings" {
+    for_each = var.node_eviction_node_pool_settings == true ? [1] : []
+    content {
+    
+        eviction_grace_duration = var.eviction_grace_duration
+        is_force_delete_after_grace_duration = var.is_force_delete_after_grace_duration
+    }
+  }
+
   defined_tags = var.defined_tags
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -169,10 +169,18 @@ variable "ssh_public_key" {
   default = ""
 }
 
-variable "defined_tags" {
-  default = {}
+variable "node_eviction_node_pool_settings" {
+  default = false
 }
 
-locals {
-  availability_domains = var.availability_domain == "" ? data.oci_identity_availability_domains.ADs.availability_domains : data.oci_identity_availability_domains.AD.availability_domains
+variable "eviction_grace_duration" {
+  default = "PT60M"
+}
+
+variable "is_force_delete_after_grace_duration" {
+  default = true
+}
+
+variable "defined_tags" {
+  default = {}
 }


### PR DESCRIPTION
## What's changed
- Support for OKE images as default
- Support for aarch64 for A1 shapes.
- added K8S version 1.24.1 as the default.
- dynamic node_eviction_node_pool_settings parameters.