### PR TITLE
Update locals.tf

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -3,5 +3,5 @@ locals {
   is_arm_node_shape          = length(regexall("A1", var.node_shape)) > 0 ? true : false
   arm_node_shape             = local.is_arm_node_shape ? "aarch64-" : ""
   k8s_version_without_v_char = substr(var.k8s_version,1,6)
-  node_image_regex           = "Oracle-Linux-${var.node_linux_version}-${local.arm_node_shape}.+-OKE-${local.k8s_version_without_v_char}-[0-9]+"
+  node_image_regex           = "Oracle-Linux-${var.node_linux_version}-${local.arm_node_shape}[0-9]{4}.+-OKE-${local.k8s_version_without_v_char}-[0-9]+"
 }


### PR DESCRIPTION
We should try to capture the date after the Linux version otherwise `.*` will capture aarch64 even if we are not using an ARM shape (in this case, I'm capturing only the year and it works fine, but it can be extended to capture month and day).